### PR TITLE
Improve ECS errors outputs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,35 @@
+name: "Build"
+defaults:
+  run:
+    shell: bash
+env:
+  DOCKER_REGISTRY: hazelops
+  DOCKER_IMAGE_NAME: ecs-deploy
+
+on:
+  push:
+    branches:
+      - master
+      - develop
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build Image
+        run: |
+          docker build -t $DOCKER_REGISTRY/$DOCKER_IMAGE_NAME:latest .
+
+      - name: Push
+        run: |
+          docker push $DOCKER_REGISTRY/$DOCKER_IMAGE_NAME:latest

--- a/ecs_deploy/cli.py
+++ b/ecs_deploy/cli.py
@@ -419,6 +419,7 @@ def wait_for_finish(action, timeout, title, success_message, failure_message,
         click.secho('.', nl=False)
         service = action.get_service()
         inspected_until = inspect_errors(
+            action,
             service=service,
             failure_message=failure_message,
             ignore_warnings=ignore_warnings,
@@ -431,6 +432,7 @@ def wait_for_finish(action, timeout, title, success_message, failure_message,
             sleep(sleep_time)
 
     inspect_errors(
+        action,
         service=service,
         failure_message=failure_message,
         ignore_warnings=ignore_warnings,
@@ -552,7 +554,7 @@ def print_diff(task_definition, title='Updating task definition'):
         click.secho('')
 
 
-def inspect_errors(service, failure_message, ignore_warnings, since, timeout):
+def inspect_errors(action, service, failure_message, ignore_warnings, since, timeout):
     error = False
     last_error_timestamp = since
 
@@ -589,10 +591,12 @@ def inspect_errors(service, failure_message, ignore_warnings, since, timeout):
     if timeout:
         error = True
         failure_message += ' due to timeout. Please see: ' \
-                           'https://github.com/fabfuel/ecs-deploy#timeout'
+                           'https://github.com/fabfuel/ecs-deploy#timeout \n'
         click.secho('')
 
     if error:
+        task_stopped_reason = action.get_task_stop_reason(service)
+        failure_message += 'Stopped reason of tasks:\n %s\n' % (task_stopped_reason)
         raise TaskPlacementError(failure_message)
 
     return last_error_timestamp

--- a/ecs_deploy/cli.py
+++ b/ecs_deploy/cli.py
@@ -404,7 +404,7 @@ def diff(task, revision_a, revision_b, region, access_key_id, secret_access_key,
 
 
 def wait_for_finish(action, timeout, title, success_message, failure_message,
-                    ignore_warnings, sleep_time=1):
+                    ignore_warnings, sleep_time=1, rollback_now=False):
     click.secho(title, nl=False)
     waiting_timeout = datetime.now() + timedelta(seconds=timeout)
     service = action.get_service()
@@ -426,7 +426,8 @@ def wait_for_finish(action, timeout, title, success_message, failure_message,
             since=inspected_until,
             timeout=False
         )
-        waiting = not action.is_deployed(service)
+        waiting = not action.is_deployed(service, rollback_now)
+        rollback_now=False
 
         if waiting:
             sleep(sleep_time)
@@ -445,7 +446,7 @@ def wait_for_finish(action, timeout, title, success_message, failure_message,
 
 def deploy_task_definition(deployment, task_definition, title, success_message,
                            failure_message, timeout, deregister,
-                           previous_task_definition, ignore_warnings, sleep_time):
+                           previous_task_definition, ignore_warnings, sleep_time, rollback_now=False):
     click.secho('Updating service')
     deployment.deploy(task_definition)
 
@@ -463,7 +464,8 @@ def deploy_task_definition(deployment, task_definition, title, success_message,
         success_message=success_message,
         failure_message=failure_message,
         ignore_warnings=ignore_warnings,
-        sleep_time=sleep_time
+        sleep_time=sleep_time,
+        rollback_now=rollback_now
     )
 
     if deregister:
@@ -514,7 +516,8 @@ def rollback_task_definition(deployment, old, new, timeout=600, sleep_time=1):
         deregister=True,
         previous_task_definition=new,
         ignore_warnings=False,
-        sleep_time=sleep_time
+        sleep_time=sleep_time,
+        rollback_now=True
     )
     click.secho(
         'Deployment failed, but service has been rolled back to previous '

--- a/ecs_deploy/ecs.py
+++ b/ecs_deploy/ecs.py
@@ -74,6 +74,13 @@ class EcsClient(object):
             serviceName=service_name
         )
 
+    def list_stopped_tasks(self, cluster_name, service_name):
+        return self.boto.list_tasks(
+            cluster=cluster_name,
+            serviceName=service_name,
+            desiredStatus='STOPPED'
+        )
+
     def describe_tasks(self, cluster_name, task_arns):
         return self.boto.describe_tasks(cluster=cluster_name, tasks=task_arns)
 
@@ -720,6 +727,20 @@ class EcsAction(object):
             task_arns=running_tasks[u'taskArns']
         )
         return service.desired_count == running_count
+
+    def get_task_stop_reason(self, service):
+        stopped_tasks = self._client.list_stopped_tasks(
+            cluster_name=service.cluster,
+            service_name=service.name
+        )
+        task_arns=stopped_tasks[u'taskArns']
+        tasks_details = self._client.describe_tasks(
+            cluster_name=self._cluster_name,
+            task_arns=task_arns
+        )
+        for task in tasks_details[u'tasks']:
+            task_stopped_reason = task[u'stoppedReason']
+        return task_stopped_reason
 
     def get_running_tasks_count(self, service, task_arns):
         running_count = 0

--- a/ecs_deploy/ecs.py
+++ b/ecs_deploy/ecs.py
@@ -707,7 +707,9 @@ class EcsAction(object):
         )
         return EcsService(self._cluster_name, response[u'service'])
 
-    def is_deployed(self, service):
+    def is_deployed(self, service, rollback_now):
+        if rollback_now:
+            self.FAILED_TASKS = service.primary_deployment.failed_tasks   
         if service.primary_deployment.has_failed:
             raise EcsDeploymentError(u'Deployment Failed! ' + service.primary_deployment.rollout_state_reason)
         if service.primary_deployment.failed_tasks > 0 and service.primary_deployment.failed_tasks != self.FAILED_TASKS:


### PR DESCRIPTION
- Added ability to print out ECS task stopped reason after ECS deployment failure

Testing:
[![asciicast](https://asciinema.org/a/ZkqkIBYY4SYQHhKzsxfMDIDd0.svg)](https://asciinema.org/a/ZkqkIBYY4SYQHhKzsxfMDIDd0)